### PR TITLE
detect_runtime 関数において #include "hsp3dish.as" 等の前に空白以外の文字列があると認識されない問題を修正

### DIFF
--- a/templates/sourceCreate.tmpl
+++ b/templates/sourceCreate.tmpl
@@ -437,12 +437,12 @@ Module["preRun"].push(function () {
 	function detect_runtime() {
 		var text = editor.getValue();
 
-		if (text.match(/^\s*\#include\s+"hsp3dish.as"/g)) {
+		if (text.match(/^\s*\#include\s+"hsp3dish.as"/gm)) {
 			console.log("HSP3Dish runtime detected");
 
 			return "HSP3Dish";
 		}
-		if (text.match(/^\s*\#include\s+"hgimg4.as"/g)) {
+		if (text.match(/^\s*\#include\s+"hgimg4.as"/gm)) {
 			console.log("HGIMG4 runtime detected");
 
 			return "HGIMG4";

--- a/templates/sourceCreate.tmpl
+++ b/templates/sourceCreate.tmpl
@@ -437,12 +437,12 @@ Module["preRun"].push(function () {
 	function detect_runtime() {
 		var text = editor.getValue();
 
-		if (text.match(/^\s*\#include\s+"hsp3dish.as"/gm)) {
+		if (text.match(/^\s*\#\s*include\s*"hsp3dish\.as"/gm)) {
 			console.log("HSP3Dish runtime detected");
 
 			return "HSP3Dish";
 		}
-		if (text.match(/^\s*\#include\s+"hgimg4.as"/gm)) {
+		if (text.match(/^\s*\#\s*include\s*"hgimg4\.as"/gm)) {
 			console.log("HGIMG4 runtime detected");
 
 			return "HGIMG4";

--- a/templates/sourceEdit.tmpl
+++ b/templates/sourceEdit.tmpl
@@ -390,12 +390,12 @@ Module["preRun"].push(function () {
 	function detect_runtime() {
 		var text = editor.getValue();
 
-		if (text.match(/^\s*\#include\s+"hsp3dish.as"/gm)) {
+		if (text.match(/^\s*\#\s*include\s*"hsp3dish\.as"/gm)) {
 			console.log("HSP3Dish runtime detected");
 
 			return "HSP3Dish";
 		}
-		if (text.match(/^\s*\#include\s+"hgimg4.as"/gm)) {
+		if (text.match(/^\s*\#\s*include\s*"hgimg4\.as"/gm)) {
 			console.log("HGIMG4 runtime detected");
 
 			return "HGIMG4";

--- a/templates/sourceEdit.tmpl
+++ b/templates/sourceEdit.tmpl
@@ -390,12 +390,12 @@ Module["preRun"].push(function () {
 	function detect_runtime() {
 		var text = editor.getValue();
 
-		if (text.match(/^\s*\#include\s+"hsp3dish.as"/g)) {
+		if (text.match(/^\s*\#include\s+"hsp3dish.as"/gm)) {
 			console.log("HSP3Dish runtime detected");
 
 			return "HSP3Dish";
 		}
-		if (text.match(/^\s*\#include\s+"hgimg4.as"/g)) {
+		if (text.match(/^\s*\#include\s+"hgimg4.as"/gm)) {
 			console.log("HGIMG4 runtime detected");
 
 			return "HGIMG4";


### PR DESCRIPTION
さめたすたすさんのツイート（ https://twitter.com/sharkpp/status/682157616986886144 ）より
